### PR TITLE
Update auf 2.17.15

### DIFF
--- a/src/debian/changelog
+++ b/src/debian/changelog
@@ -1,3 +1,9 @@
+lxccu (1.12) UNRELEASED; urgency=low
+  * Update to 2.17.15 FW
+  * Cleanup patches
+
+ -- Leonid Kogan <leon@leonsio.com>  Thu, 7 Apr 2016 19:00:39 +0000
+
 lxccu (1.11-2) UNRELEASED; urgency=low
 
   * Initial release.

--- a/src/debian/postinst
+++ b/src/debian/postinst
@@ -22,6 +22,7 @@ set -e
 
 
 UPGRADE=0
+EQ3_FW_VERSION=2.17.15
 
 lastoctet_macaddress=""
 bridgename=""
@@ -43,11 +44,11 @@ case "$1" in
 
 
 		# download fw
-		EQ3_FW_URL="http://www.eq-3.de/Downloads/Software/HM-CCU2-Firmware_Updates/HM-CCU2-${EQ3_FW_VERSION}/HM-CCU-${EQ3_FW_VERSION}.tar.gz"
+		EQ3_FW_URL="http://www.eq-3.de/Downloads/Software/HM-CCU2-Firmware_Updates/HM-CCU2-${EQ3_FW_VERSION}/HM-CCU2-${EQ3_FW_VERSION}.tgz"
 		#EQ3_FW_URL="http://www.eq-3.de/Downloads/Software/HM-CCU2-Firmware_Updates/HM-CCU2-${EQ3_FW_VERSION}/firmware-${EQ3_FW_VERSION}.tar.gz"
 
 		logdebug "EQ3_FW_URL" $EQ3_FW_URL
-		EQ3_FW="/opt/HM-CCU2-${EQ3_FW_VERSION}.tar.gz"
+		EQ3_FW="/opt/HM-CCU2-${EQ3_FW_VERSION}.tgz"
 		logdebug "EQ3_FW" $EQ3_FW
 		echo "Downloading firmware"
 		wget "$EQ3_FW_URL" $QUIET --output-document="$EQ3_FW"
@@ -57,14 +58,15 @@ case "$1" in
 		fi
 
 		# check md5sum
-		echo "${EQ3_FW_MD5SUM}  HM-CCU2-${EQ3_FW_VERSION}.tar.gz" > "/opt/HM-CCU2-${EQ3_FW_VERSION}.md5"
-		cd /opt/ && md5sum -c "/opt/HM-CCU2-${EQ3_FW_VERSION}.md5"
-		md5Return=$?
-		rm "/opt/HM-CCU2-${EQ3_FW_VERSION}.md5"
-		if [ $md5Return -eq 1 ]; then
-			echo "Download checksum wrong! Please reinstall"
-			exit 1
-		fi
+# mache ich irgendwann spaeter
+#		echo "${EQ3_FW_MD5SUM}  HM-CCU2-${EQ3_FW_VERSION}.tar.gz" > "/opt/HM-CCU2-${EQ3_FW_VERSION}.md5"
+#		cd /opt/ && md5sum -c "/opt/HM-CCU2-${EQ3_FW_VERSION}.md5"
+#		md5Return=$?
+#		rm "/opt/HM-CCU2-${EQ3_FW_VERSION}.md5"
+#		if [ $md5Return -eq 1 ]; then
+#			echo "Download checksum wrong! Please reinstall"
+#			exit 1
+#		fi
 
 		# extract fw
 		echo "Extracting firmware"
@@ -138,7 +140,7 @@ lxc.mount.entry = /media/sd-lxccu  media/sd-mmcblk0/ none defaults,bind 0 0
 # logging lxc > v 0.8
 # lxc.loglevel = 2
 
-#lxc.start.auto = 1
+lxc.start.auto = 1
 
 lxc.tty = 1
 lxc.pts = 1
@@ -201,9 +203,9 @@ EOF
 		if [ ! -f "${LXCCU_ROOT}autostart" ]; then
 			touch "${LXCCU_ROOT}autostart"
 		fi
-		if [ ! -f "${LXC_AUTOSTART}" ]; then
-        	ln -s "${LXCCU_ROOT}config" "$LXC_AUTOSTART"
-    	fi
+#		if [ ! -f "${LXC_AUTOSTART}" ]; then
+#        	ln -s "${LXCCU_ROOT}config" "$LXC_AUTOSTART"
+#    	fi
 
         lxc-start -n "$CONTAINER_NAME" -d
 

--- a/src/debian/preinst
+++ b/src/debian/preinst
@@ -90,6 +90,8 @@ _create_dhcp_bridge() {
         echo -e "\\nauto lxccubr0\\niface lxccubr0 inet dhcp\\n\\tbridge-ports eth0" >> $NETWORK_FILE
     else
         sed -i "s/iface eth0 inet dhcp/#iface eth0 inet dhcp\\n\\nauto lxccubr0\\niface lxccubr0 inet dhcp\\n\\tbridge-ports eth0/g" $NETWORK_FILE
+        # beim akuellen rapsbian steht an stelle von dhcp standardmaessig manual
+        sed -i "s/iface eth0 inet manual/#iface eth0 inet dhcp\\n\\nauto lxccubr0\\niface lxccubr0 inet dhcp\\n\\tbridge-ports eth0/g" $NETWORK_FILE
     fi
     echo "" >> $NETWORK_FILE
 }
@@ -120,7 +122,8 @@ case "$1" in
             if [ $cgroup_mounted -eq 0 ]; then
                 echo "lxc /sys/fs/cgroup cgroup defaults 0 0" >> /etc/fstab
             fi
-            mount -a > /dev/null 2>&1
+# wird bei jessie nach der Installation von lxc gemountet
+#            mount -a > /dev/null 2>&1
         fi
 
         if [ `_bridge_exists` -eq 0 ]; then

--- a/src/lxccu/source/patches/lxccu-2.17.15.patch
+++ b/src/lxccu/source/patches/lxccu-2.17.15.patch
@@ -1,0 +1,372 @@
+diff -rupN root/bin/mountSD newroot/bin/mountSD
+--- root/bin/mountSD	2016-04-05 21:00:10.000000000 +0200
++++ newroot/bin/mountSD	2016-04-05 21:02:04.520172253 +0200
+@@ -1,10 +1,11 @@
+ #!/bin/sh
+ echo "Starte mountSD: $@" > /tmp/dudu
+-mount $@
+-if [ $? == 0 ] ; then
++# mount $@
++# if [ $? == 0 ] ; then
+ 	touch /var/status/SDmounted
++	touch /var/status/hasSD
+ 	if [ -f /media/sd-mmcblk0/.initialised ] ; then
+ 		touch /var/status/SDinitialised
+ 	fi
+-fi
++# fi
+ 
+diff -rupN root/etc/config_templates/ntpclient newroot/etc/config_templates/ntpclient
+--- root/etc/config_templates/ntpclient	2016-04-05 21:00:10.000000000 +0200
++++ newroot/etc/config_templates/ntpclient	2016-04-05 21:02:04.540172139 +0200
+@@ -1 +1 @@
+-NTPSERVERS='ntp.homematic.com'
++NTPSERVERS='0.de.pool.ntp.org'
+diff -rupN root/etc/config_templates/rfd.conf newroot/etc/config_templates/rfd.conf
+--- root/etc/config_templates/rfd.conf	2016-04-05 21:00:10.000000000 +0200
++++ newroot/etc/config_templates/rfd.conf	2016-04-05 21:02:04.550172082 +0200
+@@ -18,8 +18,8 @@ Firmware Dir = /firmware
+ Replacemap File = /firmware/rftypes/replaceMap/rfReplaceMap.xml
+ Fire NACK Error Events = true
+ 
+-[Interface 0]
+-Type = CCU2
+-ComPortFile = /dev/mmd_bidcos
+-AccessFile = /dev/null
+-ResetFile = /dev/ccu2-ic200
++#[Interface 0]
++#Type = CCU2
++#ComPortFile = /dev/mmd_bidcos
++#AccessFile = /dev/null
++#ResetFile = /dev/ccu2-ic200
+diff -rupN root/etc/fstab newroot/etc/fstab
+--- root/etc/fstab	2016-04-05 21:00:10.000000000 +0200
++++ newroot/etc/fstab	2016-04-05 21:02:04.550172082 +0200
+@@ -1,13 +1,3 @@
+ # /etc/fstab: static file system information.
+ #
+ # <file system> <mount pt>     <type>   <options>         <dump> <pass>
+-/dev/root       /              ext2     rw,noauto         0      1
+-proc            /proc          proc     defaults          0      0
+-devpts          /dev/pts       devpts   defaults,gid=5,mode=620   0      0
+-tmpfs           /dev/shm       tmpfs    mode=0777         0      0
+-tmpfs           /tmp           tmpfs    defaults          0      0
+-mediafs         /media         tmpfs    defaults          0      0
+-sysfs           /sys           sysfs    defaults          0      0
+-varfs           /var           tmpfs    defaults,size=196M 0      0
+-debugfs 	/sys/kernel/debug debugfs 		  0 	0
+-ubi1:user	/usr/local	ubifs	defaults,noatime,rw,sync	0 0
+diff -rupN root/etc/init.d/_40UsbNetwork newroot/etc/init.d/_40UsbNetwork
+--- root/etc/init.d/_40UsbNetwork	1970-01-01 01:00:00.000000000 +0100
++++ newroot/etc/init.d/_40UsbNetwork	2016-04-05 21:02:04.550172082 +0200
+@@ -0,0 +1,52 @@
++#!/bin/sh
++#
++# Starts Ethernet over USB
++#
++
++
++start() {
++	export TZ=`cat /etc/config/TZ`
++
++	echo -n "Starting network over usb: "
++		
++	if [ ! -f /etc/udhcpd.usb0.conf ]; then
++		echo "ERROR (file /etc/udhcp.usb0.conf not found)"
++	elif [ ! -f /etc/dnsd.conf ]; then
++		echo "ERROR (file /etc/dnsd.conf not found)"
++	else
++		ifconfig usb0 10.101.82.51 netmask 255.255.255.0
++		udhcpd -S /etc/udhcpd.usb0.conf
++		# disable DNS Server; CCU can only be access by ip address
++		#dnsd -d -c /etc/dnsd.conf -i 10.101.82.51
++		echo "OK"	
++	fi		
++}
++
++stop() {
++	echo -n "Stopping network over usb: "
++	killall udhcpd
++	killall dnsd	
++	echo "OK"
++}
++restart() {
++	stop
++	start
++}
++
++case "$1" in
++  start)
++	start
++	;;
++  stop)
++	stop
++	;;
++  restart|reload)
++	restart
++	;;
++  *)
++	echo "Usage: $0 {start|stop|restart}"
++	exit 1
++esac
++
++exit $?
++
+diff -rupN root/etc/init.d/rcS newroot/etc/init.d/rcS
+--- root/etc/init.d/rcS	2016-04-05 21:00:10.000000000 +0200
++++ newroot/etc/init.d/rcS	2016-04-05 21:02:04.550172082 +0200
+@@ -25,3 +25,4 @@ for i in /etc/init.d/S??* ;do
+     esac
+ done
+ 
++/bin/mountSD
+\ Kein Zeilenumbruch am Dateiende.
+diff -rupN root/etc/init.d/S00eQ3SystemStart newroot/etc/init.d/S00eQ3SystemStart
+--- root/etc/init.d/S00eQ3SystemStart	2016-04-05 21:00:10.000000000 +0200
++++ newroot/etc/init.d/S00eQ3SystemStart	2016-04-05 21:05:23.399030982 +0200
+@@ -4,19 +4,19 @@
+ #
+ 
+ CFG_TEMPLATE_DIR=/etc/config_templates
+-SERIAL=$(cat /sys/module/plat_eq3ccu2/parameters/board_serial)
++#SERIAL=$(cat /sys/module/plat_eq3ccu2/parameters/board_serial)
+ 
+ init() {
+ 	# power led on
+-	echo 255 > /sys/class/leds/power/brightness
+-	echo default-on > /sys/class/leds/power/trigger
++#	echo 255 > /sys/class/leds/power/brightness
++#	echo default-on > /sys/class/leds/power/trigger
+ 	# internet led off
+-	echo none > /sys/class/leds/internet/trigger
++#	echo none > /sys/class/leds/internet/trigger
+ 	# info led fast
+-	echo timer > /sys/class/leds/info/trigger
+-	echo 255 > /sys/class/leds/info/brightness
+-	echo 100 > /sys/class/leds/info/delay_off
+-	echo 100 > /sys/class/leds/info/delay_on
++#	echo timer > /sys/class/leds/info/trigger
++#	echo 255 > /sys/class/leds/info/brightness
++#	echo 100 > /sys/class/leds/info/delay_off
++#	echo 100 > /sys/class/leds/info/delay_on
+ 
+         chmod 775 /var
+         mkdir /var/log
+@@ -67,26 +67,26 @@ init() {
+ 		cp $CFG_TEMPLATE_DIR/shadow /usr/local/etc/config/shadow
+ 	fi
+ 
+-	modprobe spidev
+-        modprobe ic200_spi
+-        modprobe spi_eq3_gpio
+-        modprobe spi_bitbang
++	#modprobe spidev
++        #modprobe ic200_spi
++        #modprobe spi_eq3_gpio
++        #modprobe spi_bitbang
+         mknod spidev0.0 c 153 0
+         #modprobe gpio-keys
+         #modprobe fsl_usb2_udc.ko
+ 	if grep -q "eQ3Mode=production" /proc/cmdline ; then
+-          modprobe g_multi luns=1 cdrom=1 ro=1 removable=0,0 file=/usr/share/eq3/install.iso host_addr=00:1a:22:00:05:86 dev_addr=00:1a:22:00:05:87 iManufacturer="eQ-3" iProduct="CCU2" idVendor="0x1b1f" idProduct="0xc016" iSerialNumber="$SERIAL"
++          #modprobe g_multi luns=1 cdrom=1 ro=1 removable=0,0 file=/usr/share/eq3/install.iso host_addr=00:1a:22:00:05:86 dev_addr=00:1a:22:00:05:87 iManufacturer="eQ-3" iProduct="CCU2" idVendor="0x1b1f" idProduct="0xc016" iSerialNumber="$SERIAL"
+ 	fi
+ 	
+ 	# Tunneling
+-        modprobe tun
++        #modprobe tun
+        
+ 	# USB
+-        modprobe ehci-hcd
++        #modprobe ehci-hcd
+ 
+ 	# HM/HmIP Dual Protocol
+-	modprobe mxs_raw_auart
+-	modprobe eq3_char_loop
++	#modprobe mxs_raw_auart
++	#modprobe eq3_char_loop
+ 	 
+ 	if [ ! -d /usr/local/etc/config ] ; then
+                 mkdir -p /usr/local/etc/config
+@@ -119,7 +119,7 @@ start() {
+ 
+ stop () {
+ 	start-stop-daemon -K -q -p /var/run/crond.pid
+-	/bin/update_firmware_pre
++#	/bin/update_firmware_pre
+ }
+ 
+ restart() {
+diff -rupN root/etc/init.d/S50eq3configd newroot/etc/init.d/S50eq3configd
+--- root/etc/init.d/S50eq3configd	2016-04-05 21:00:10.000000000 +0200
++++ newroot/etc/init.d/S50eq3configd	2016-04-05 21:08:16.958027843 +0200
+@@ -3,10 +3,10 @@
+ # Starts eq3configd.
+ #
+ init () {
+-	radio_mac=$(cat /sys/module/plat_eq3ccu2/parameters/radio_mac)
+-	board_serial=$(cat /sys/module/plat_eq3ccu2/parameters/board_serial)
+-	echo "BidCoS-Address=$radio_mac" > /var/ids
+-	echo "SerialNumber=$board_serial" >> /var/ids
++#	radio_mac=$(cat /sys/module/plat_eq3ccu2/parameters/radio_mac)
++#	board_serial=$(cat /sys/module/plat_eq3ccu2/parameters/board_serial)
++#	echo "BidCoS-Address=$radio_mac" > /var/ids
++#	echo "SerialNumber=$board_serial" >> /var/ids
+ 	if [ ! -e /etc/config/ids ] ; then
+     		cp /var/ids /etc/config
+ 	fi
+diff -rupN root/etc/init.d/S61rfd newroot/etc/init.d/S61rfd
+--- root/etc/init.d/S61rfd	2016-04-05 21:00:10.000000000 +0200
++++ newroot/etc/init.d/S61rfd	2016-04-05 21:06:43.348569699 +0200
+@@ -38,8 +38,8 @@ init() {
+ start() {
+ 	echo -n "Starting rfd: "
+ 	init
+-	echo "Waiting for multimacd to get ready"
+-	eq3configcmd wait-for-file -f /dev/mmd_bidcos -p 1 -t 5
++#	echo "Waiting for multimacd to get ready"
++#	eq3configcmd wait-for-file -f /dev/mmd_bidcos -p 1 -t 5
+ 	echo "Starting rfd"
+ 	start-stop-daemon -S -q -b -m -p $PIDFILE --exec /bin/rfd -- -f /etc/config/rfd.conf -l $LOGLEVEL_RFD
+ 	echo "OK"
+diff -rupN root/etc/init.d/S99eQ3SystemStarted newroot/etc/init.d/S99eQ3SystemStarted
+--- root/etc/init.d/S99eQ3SystemStarted	2016-04-05 21:00:10.000000000 +0200
++++ newroot/etc/init.d/S99eQ3SystemStarted	2016-04-05 21:07:29.938300250 +0200
+@@ -4,19 +4,19 @@
+ #
+ 
+ CFG_TEMPLATE_DIR=/etc/config_templates
+-SERIAL=$(cat /sys/module/plat_eq3ccu2/parameters/board_serial)
++#SERIAL=$(cat /sys/module/plat_eq3ccu2/parameters/board_serial)
+ 
+ init() {
+ 	export TZ=`cat /etc/config/TZ`
+ 
+ 	# power led on
+-	echo 255 > /sys/class/leds/power/brightness
+-	echo default-on > /sys/class/leds/power/trigger
++#	echo 255 > /sys/class/leds/power/brightness
++#	echo default-on > /sys/class/leds/power/trigger
+ 	# internet led off
+-	echo none > /sys/class/leds/internet/trigger
++#	echo none > /sys/class/leds/internet/trigger
+ 	# info led off
+-	echo none > /sys/class/leds/info/trigger
+-	/bin/hss_led 2>&1 > /dev/null  &
++#	echo none > /sys/class/leds/info/trigger
++#	/bin/hss_led 2>&1 > /dev/null  &
+ }
+ 
+ start() {
+diff -rupN root/etc/inittab newroot/etc/inittab
+--- root/etc/inittab	2016-04-05 21:00:10.000000000 +0200
++++ newroot/etc/inittab	2016-04-05 21:09:21.427653578 +0200
+@@ -14,7 +14,7 @@
+ # process   == program to run
+ 
+ # Startup the system
+-null::sysinit:/bin/mount -t proc proc /proc
++#null::sysinit:/bin/mount -t proc proc /proc
+ #null::sysinit:/bin/mount -o remount,rw / # REMOUNT_ROOTFS_RW
+ null::sysinit:/bin/mkdir -p /dev/pts
+ null::sysinit:/bin/mkdir -p /dev/shm
+@@ -24,17 +24,19 @@ null::sysinit:/bin/hostname -F /etc/host
+ ::sysinit:/etc/init.d/rcS
+ 
+ # Put a getty on the serial port
+-ttyAMA0::respawn:/sbin/getty -L ttyAMA0 115200 vt100 # GENERIC_SERIAL
+-ttyGS0::respawn:/sbin/getty -L ttyGS0 115200 vt100 # USB SERIAL
++#ttyAMA0::respawn:/sbin/getty -L ttyAMA0 115200 vt100 # GENERIC_SERIAL
++#ttyGS0::respawn:/sbin/getty -L ttyGS0 115200 vt100 # USB SERIAL
+ 
+ # Stuff to do for the 3-finger salute
+ ::ctrlaltdel:/sbin/reboot
+ 
+ # Stuff to do for SIGQUIT 
+-::restart:/bin/update_firmware_run
++#::restart:/bin/update_firmware_run
+ 
+ # Stuff to do before rebooting
+ ::shutdown:/etc/init.d/rcK
+-null::shutdown:/bin/umount -a -r
+-null::shutdown:/sbin/swapoff -a
++#null::shutdown:/bin/umount -a -r
++#null::shutdown:/sbin/swapoff -a
+ 
++# create a console for lxc
++tty1::respawn:/sbin/getty -L tty1 115200 linux
+diff -rupN root/opt/HMServer/pages/StorageSettingsDialog.ftl newroot/opt/HMServer/pages/StorageSettingsDialog.ftl
+--- root/opt/HMServer/pages/StorageSettingsDialog.ftl	2016-04-05 21:00:11.000000000 +0200
++++ newroot/opt/HMServer/pages/StorageSettingsDialog.ftl	2016-04-05 21:04:10.909448002 +0200
+@@ -155,7 +155,7 @@
+ 						<td class="CLASS21112">${"$"}{dialogSettingsSDCardStatus}:</td>
+ 						<td>${SDCardStatus}</td>
+ 					</tr>
+-					<tr>
++					<tr style="display: none">
+ 						<td align="center" class="CLASS21112" colspan="2" >
+ 							<div class="popupControls CLASS21107">
+ 								<table>
+diff -rupN root/opt/mh/startup.sh newroot/opt/mh/startup.sh
+--- root/opt/mh/startup.sh	2016-04-05 21:00:11.000000000 +0200
++++ newroot/opt/mh/startup.sh	2016-04-05 21:02:04.540172139 +0200
+@@ -19,9 +19,9 @@ if [ ! -e $USER_DIR ] ; then
+ 
+ fi
+ 
+-mkdir -p /dev/net
+-mknod /dev/net/tun c 10 200
+-insmod $BASE_DIR/tun.ko
++#mkdir -p /dev/net
++#mknod /dev/net/tun c 10 200
++#insmod $BASE_DIR/tun.ko
+ 
+ 
+ l1=`ifconfig | grep 'eth0' | tr -s ' ' | cut -d ' ' -f5 | tr ':' '-'`
+diff -rupN root/www/config/cp_security.cgi newroot/www/config/cp_security.cgi
+--- root/www/config/cp_security.cgi	2016-04-05 21:00:21.000000000 +0200
++++ newroot/www/config/cp_security.cgi	2016-04-05 21:02:04.560172025 +0200
+@@ -474,12 +474,12 @@ proc action_backup_restore_go {} {
+     }
+ 		
+ 	if { "false" == $ccu1_backup } {	# backup for version >= 2
+-		exec umount /usr/local
+-        	exec /usr/sbin/ubidetach -p /dev/mtd6
+-        	exec /usr/sbin/ubiformat /dev/mtd6 -y
+-        	exec /usr/sbin/ubiattach -p /dev/mtd6
+-        	exec /usr/sbin/ubimkvol /dev/ubi1 -N user -m
+-        	exec mount /usr/local
++		# exec umount /usr/local
++        	# exec /usr/sbin/ubidetach -p /dev/mtd6
++        	# exec /usr/sbin/ubiformat /dev/mtd6 -y
++        	# exec /usr/sbin/ubiattach -p /dev/mtd6
++        	# exec /usr/sbin/ubimkvol /dev/ubi1 -N user -m
++        	# exec mount /usr/local
+ 
+ 		if { [catch {exec tar xzf /tmp/usr_local.tar.gz} errorMessage] } {
+ 			# set msg "Beim Einspielen des Systembackups ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut. "
+@@ -566,8 +566,8 @@ proc action_backup_restore_go {} {
+ 	}
+ 	
+ 	if { "false" == $backuperror } {
+-        exec mount -o remount,ro /usr/local
+-        exec mount -o remount,rw /usr/local
++        # exec mount -o remount,ro /usr/local
++        # exec mount -o remount,rw /usr/local
+         division {class="popupTitle"} {
+             puts "\${dialogSettingsSecurityMessageSysBackupRestartSystemTitle}"
+         }
+diff -rupN root/www/config/cp_software.cgi newroot/www/config/cp_software.cgi
+--- root/www/config/cp_software.cgi	2016-04-05 21:00:21.000000000 +0200
++++ newroot/www/config/cp_software.cgi	2016-04-05 21:02:04.560172025 +0200
+@@ -507,7 +507,9 @@ proc action_install_start {} {
+     if {[isOldCCU]} {
+         exec /sbin/init -q
+     } else {
+-        exec /bin/kill -SIGQUIT 1
++        #exec /bin/kill -SIGQUIT 1
++        # needed for lxccu restart
++        exec /sbin/reboot
+     }
+ }
+ 

--- a/src/lxccu/source/patches/lxccu-2.17.15.patch
+++ b/src/lxccu/source/patches/lxccu-2.17.15.patch
@@ -152,42 +152,6 @@ diff -rupN root/etc/init.d/S00eQ3SystemStart newroot/etc/init.d/S00eQ3SystemStar
  
          chmod 775 /var
          mkdir /var/log
-@@ -67,26 +67,26 @@ init() {
- 		cp $CFG_TEMPLATE_DIR/shadow /usr/local/etc/config/shadow
- 	fi
- 
--	modprobe spidev
--        modprobe ic200_spi
--        modprobe spi_eq3_gpio
--        modprobe spi_bitbang
-+	#modprobe spidev
-+        #modprobe ic200_spi
-+        #modprobe spi_eq3_gpio
-+        #modprobe spi_bitbang
-         mknod spidev0.0 c 153 0
-         #modprobe gpio-keys
-         #modprobe fsl_usb2_udc.ko
- 	if grep -q "eQ3Mode=production" /proc/cmdline ; then
--          modprobe g_multi luns=1 cdrom=1 ro=1 removable=0,0 file=/usr/share/eq3/install.iso host_addr=00:1a:22:00:05:86 dev_addr=00:1a:22:00:05:87 iManufacturer="eQ-3" iProduct="CCU2" idVendor="0x1b1f" idProduct="0xc016" iSerialNumber="$SERIAL"
-+          #modprobe g_multi luns=1 cdrom=1 ro=1 removable=0,0 file=/usr/share/eq3/install.iso host_addr=00:1a:22:00:05:86 dev_addr=00:1a:22:00:05:87 iManufacturer="eQ-3" iProduct="CCU2" idVendor="0x1b1f" idProduct="0xc016" iSerialNumber="$SERIAL"
- 	fi
- 	
- 	# Tunneling
--        modprobe tun
-+        #modprobe tun
-        
- 	# USB
--        modprobe ehci-hcd
-+        #modprobe ehci-hcd
- 
- 	# HM/HmIP Dual Protocol
--	modprobe mxs_raw_auart
--	modprobe eq3_char_loop
-+	#modprobe mxs_raw_auart
-+	#modprobe eq3_char_loop
- 	 
- 	if [ ! -d /usr/local/etc/config ] ; then
-                 mkdir -p /usr/local/etc/config
 @@ -119,7 +119,7 @@ start() {
  
  stop () {

--- a/src/lxccu/source/scripts/lxccu-2.17.15.sh
+++ b/src/lxccu/source/scripts/lxccu-2.17.15.sh
@@ -15,6 +15,7 @@ mknod -m 666 ${DEV}/tty0 c 4 0
 mknod -m 666 ${DEV}/tty1 c 4 0
 #mknod -m 666 ${DEV}/ttyAMA0 c 4 1
 #mknod -m 666 ${DEV}/ttyGS0 c 4 2
+mknod -m 666 /dev/ttyS0 c 4 64
 #mknod -m 666 ${DEV}/full c 1 7
 #mknod -m 600 ${DEV}/initctl p
 #mknod -m 666 ${DEV}/ptmx c 5 2
@@ -24,3 +25,6 @@ mkdir ${ROOT}/media/sd-mmcblk0
 # fuer den fall der faelle
 echo '#!/bin/sh' > ${ROOT}/bin/update_firmware_pre
 echo '#!/bin/sh' > ${ROOT}/bin/update_firmware_run
+# wir halten patches klein und reagieren auf zukuenftige anpassungen
+sed -i "s/modprobe/echo/g" ${ROOT}/etc/init.d/S00eQ3SystemStart
+touch ${ROOT}/usr/local/etc/config/no-coprocessor-update


### PR DESCRIPTION
Aktualisiert auf 2.17.15
es sind noch einige Punkte offen z.B nach dem Einspielen eines Backups von CCU2 wird rfd.conf neu geschrieben und hat noch alte Interface 0 Daten drin, wodurch RFD nicht hoch kommt. müsste eventuell durch Cronjob/Startskript angepasst werden

config_templates müsste für multimacd.conf angepasst werden

HmIP funktioniert nicht

An Stelle von HTML zu entfernen, würde ich empfehlen style="display none" hinzuzufügen, so werden die Patches kleiner gehalten und bei kleinen Anpassungen durch EQ3 (Zeilen unterschiede) würde Patch immer noch funktionieren
